### PR TITLE
feat(sync): fix publish bugs and add 15 experimental platforms (aibeike 1.6.5 parity)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -701,6 +701,12 @@
     "message": "Yidian",
     "description": "Platform name for Yidian"
   },
+  "platformDingduanhao": {
+    "message": "Dingduanhao"
+  },
+  "platformKuaichuanhao": {
+    "message": "Kuaichuanhao"
+  },
   "platformPinduoduo": {
     "message": "Pinduoduo",
     "description": "Platform name for Pinduoduo"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -685,6 +685,14 @@
     "message": "Sohu",
     "description": "Platform name for Sohu"
   },
+  "platformAliyun": {
+    "message": "Aliyun",
+    "description": "Platform name for Aliyun"
+  },
+  "platformTencentyun": {
+    "message": "Tencent Cloud",
+    "description": "Platform name for Tencent Cloud"
+  },
   "platformNetease": {
     "message": "NetEase",
     "description": "Platform name for NetEase"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -521,6 +521,10 @@
     "message": "Reddit",
     "description": "Platform name for Reddit"
   },
+  "platformPinterest": {
+    "message": "Pinterest",
+    "description": "Platform name for Pinterest"
+  },
   "platformWeiXinVideo": {
     "message": "WeiXinVideo",
     "description": "Platform name for WeiXinVideo"
@@ -1011,6 +1015,10 @@
   },
   "platformLizhi": {
     "message": "LiZhi"
+  },
+  "platformSpotify": {
+    "message": "Spotify",
+    "description": "Spotify platform name"
   },
   "refreshAccountsTitle": {
     "message": "Refresh Accounts",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1128,6 +1128,15 @@
     "message": "Autohome",
     "description": "Autohome platform name"
   },
+  "platformJianpian": {
+    "message": "Jianpian"
+  },
+  "platformTonghuashun": {
+    "message": "Tonghuashun"
+  },
+  "platformDongchedi": {
+    "message": "Dongchedi"
+  },
   "platformIqiyi": {
     "message": "iQiyi",
     "description": "iQiyi platform name"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -1102,6 +1102,15 @@
     "message": "汽车之家",
     "description": "汽车之家 平台名称"
   },
+  "platformJianpian": {
+    "message": "美篇"
+  },
+  "platformTonghuashun": {
+    "message": "同花顺"
+  },
+  "platformDongchedi": {
+    "message": "懂车号"
+  },
   "platformIqiyi": {
     "message": "爱奇艺",
     "description": "爱奇艺 平台名称"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -528,6 +528,10 @@
     "message": "Reddit",
     "description": "Reddit 平台名称"
   },
+  "platformPinterest": {
+    "message": "Pinterest",
+    "description": "Pinterest 平台名称"
+  },
   "platformWeiXinVideo": {
     "message": "微信视频号",
     "description": "微信视频号平台名称"
@@ -985,6 +989,10 @@
   },
   "platformLizhi": {
     "message": "荔枝"
+  },
+  "platformSpotify": {
+    "message": "Spotify",
+    "description": "Spotify 平台名称"
   },
   "refreshAccountsTitle": {
     "message": "刷新账号",

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -663,6 +663,14 @@
     "message": "搜狐号",
     "description": "搜狐号平台名称"
   },
+  "platformAliyun": {
+    "message": "阿里云",
+    "description": "阿里云平台名称"
+  },
+  "platformTencentyun": {
+    "message": "腾讯云",
+    "description": "腾讯云平台名称"
+  },
   "platformNetease": {
     "message": "网易号",
     "description": "网易号平台名称"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -679,6 +679,12 @@
     "message": "一点号",
     "description": "一点号平台名称"
   },
+  "platformDingduanhao": {
+    "message": "顶端号"
+  },
+  "platformKuaichuanhao": {
+    "message": "快传号"
+  },
   "platformPinduoduo": {
     "message": "拼多多",
     "description": "拼多多平台名称"

--- a/src/sync/article.ts
+++ b/src/sync/article.ts
@@ -3,14 +3,17 @@ import { ArticleAutohome } from "./article/autohome";
 import { ArticleBaijiahao } from "./article/baijiahao";
 import { ArticleBilibili } from "./article/bilibili";
 import { ArticleCSDN } from "./article/csdn";
+import { ArticleDingduanhao } from "./article/dingduanhao";
 import { ArticleDouban } from "./article/douban";
 import { ArticleEastmoney } from "./article/eastmoney";
 import { ArticleInfoQ } from "./article/infoq";
 import { ArticleJianshu } from "./article/jianshu";
 import { ArticleJuejin } from "./article/juejin";
+import { ArticleKuaichuanhao } from "./article/kuaichuanhao";
 import { ArticleMedium } from "./article/medium";
 import { ArticleNetease } from "./article/netease";
 import { ArticleOSChina } from "./article/oschina";
+import { ArticleQQ } from "./article/qq";
 import { ArticleSegmentfault } from "./article/segmentfault";
 import { ArticleSMZDM } from "./article/smzdm";
 import { ArticleSSPai } from "./article/sspai";
@@ -21,6 +24,7 @@ import { ArticleWeixin } from "./article/weixin";
 import { ArticleWordpress } from "./article/wordpress";
 import { ArticleWoshipm } from "./article/woshipm";
 import { ArticleXueqiu } from "./article/xueqiu";
+import { ArticleYidianzixun } from "./article/yidianzixun";
 import { ArticleZhihu } from "./article/zhihu";
 import type { PlatformInfo } from "./common";
 
@@ -101,6 +105,18 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleToutiao,
     tags: ["CN"],
     accountKey: "toutiao",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 QQ ARTICLE DOM 路径
+  ARTICLE_QQ: {
+    type: "ARTICLE",
+    name: "ARTICLE_QQ",
+    homeUrl: "https://om.qq.com/",
+    faviconUrl: "https://om.qq.com/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformQiE"),
+    injectUrl: "https://om.qq.com/main/creation/article",
+    injectFunction: ArticleQQ,
+    tags: ["CN"],
+    accountKey: "qie",
   },
   ARTICLE_DOUBAN: {
     type: "ARTICLE",
@@ -289,5 +305,41 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleNetease,
     tags: ["CN"],
     accountKey: "netease",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Dingduanhao ARTICLE DOM 路径
+  ARTICLE_DINGDUANHAO: {
+    type: "ARTICLE",
+    name: "ARTICLE_DINGDUANHAO",
+    homeUrl: "https://mp.topnews.cn/",
+    faviconUrl: "https://mp.topnews.cn/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformDingduanhao"),
+    injectUrl: "https://mp.topnews.cn/#/scriptWrite",
+    injectFunction: ArticleDingduanhao,
+    tags: ["CN"],
+    accountKey: "dingduanhao",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Kuaichuanhao ARTICLE DOM 路径
+  ARTICLE_KUAICHUANHAO: {
+    type: "ARTICLE",
+    name: "ARTICLE_KUAICHUANHAO",
+    homeUrl: "https://kuaichuan.360kuai.com/",
+    faviconUrl: "https://p0.ssl.qhimg.com/t0144491522ec4696d3.png",
+    platformName: chrome.i18n.getMessage("platformKuaichuanhao"),
+    injectUrl: "https://kuaichuan.360kuai.com/#/console/publish/article",
+    injectFunction: ArticleKuaichuanhao,
+    tags: ["CN"],
+    accountKey: "kuaichuanhao",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Yidianzixun ARTICLE DOM 路径
+  ARTICLE_YIDIANZIXUN: {
+    type: "ARTICLE",
+    name: "ARTICLE_YIDIANZIXUN",
+    homeUrl: "https://mp.yidianzixun.com/",
+    faviconUrl: "https://www.yidianzixun.com/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformYidian"),
+    injectUrl: "https://mp.yidianzixun.com/#/Writing/articleEditor",
+    injectFunction: ArticleYidianzixun,
+    tags: ["CN"],
+    accountKey: "yidian",
   },
 };

--- a/src/sync/article.ts
+++ b/src/sync/article.ts
@@ -9,6 +9,7 @@ import { ArticleInfoQ } from "./article/infoq";
 import { ArticleJianshu } from "./article/jianshu";
 import { ArticleJuejin } from "./article/juejin";
 import { ArticleMedium } from "./article/medium";
+import { ArticleNetease } from "./article/netease";
 import { ArticleOSChina } from "./article/oschina";
 import { ArticleSegmentfault } from "./article/segmentfault";
 import { ArticleSMZDM } from "./article/smzdm";
@@ -276,5 +277,17 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleAutohome,
     tags: ["CN"],
     accountKey: "autohome",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 163 DOM 路径,正文图片 CDN 重传需后续 API 化
+  ARTICLE_NETEASE: {
+    type: "ARTICLE",
+    name: "ARTICLE_NETEASE",
+    homeUrl: "https://mp.163.com/",
+    faviconUrl: "https://static.ws.126.net/163/f2e/news/yxybd_pc/resource/static/share-icon.png",
+    platformName: chrome.i18n.getMessage("platformNetease"),
+    injectUrl: "https://mp.163.com/#/article-publish",
+    injectFunction: ArticleNetease,
+    tags: ["CN"],
+    accountKey: "netease",
   },
 };

--- a/src/sync/article.ts
+++ b/src/sync/article.ts
@@ -1,4 +1,5 @@
 import { Article51CTO } from "./article/51cto";
+import { ArticleAliyun } from "./article/aliyun";
 import { ArticleAutohome } from "./article/autohome";
 import { ArticleBaijiahao } from "./article/baijiahao";
 import { ArticleBilibili } from "./article/bilibili";
@@ -18,14 +19,17 @@ import { ArticleOSChina } from "./article/oschina";
 import { ArticleQQ } from "./article/qq";
 import { ArticleSegmentfault } from "./article/segmentfault";
 import { ArticleSMZDM } from "./article/smzdm";
+import { ArticleSohu } from "./article/sohu";
 import { ArticleSSPai } from "./article/sspai";
 import { ArticleSubstack } from "./article/substack";
+import { ArticleTencentyun } from "./article/tencentyun";
 import { ArticleTonghuashun } from "./article/tonghuashun";
 import { ArticleToutiao } from "./article/toutiao";
 import { ArticleWeibo } from "./article/weibo";
 import { ArticleWeixin } from "./article/weixin";
 import { ArticleWordpress } from "./article/wordpress";
 import { ArticleWoshipm } from "./article/woshipm";
+import { ArticleXArticle } from "./article/xarticle";
 import { ArticleXueqiu } from "./article/xueqiu";
 import { ArticleYidianzixun } from "./article/yidianzixun";
 import { ArticleZhihu } from "./article/zhihu";
@@ -87,6 +91,30 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleSegmentfault,
     tags: ["CN"],
     accountKey: "segmentfault",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Aliyun ARTICLE DOM 路径
+  ARTICLE_ALIYUN: {
+    type: "ARTICLE",
+    name: "ARTICLE_ALIYUN",
+    homeUrl: "https://developer.aliyun.com/",
+    faviconUrl: "https://img.alicdn.com/tfs/TB1_ZXuNcfpK1RjSZFOXXa6nFXa-32-32.ico",
+    platformName: chrome.i18n.getMessage("platformAliyun"),
+    injectUrl: "https://developer.aliyun.com/article/new",
+    injectFunction: ArticleAliyun,
+    tags: ["CN"],
+    accountKey: "aliyun",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 TencentYun ARTICLE DOM 路径
+  ARTICLE_TENCENTYUN: {
+    type: "ARTICLE",
+    name: "ARTICLE_TENCENTYUN",
+    homeUrl: "https://cloud.tencent.com/developer",
+    faviconUrl: "https://cloud.tencent.com/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformTencentyun"),
+    injectUrl: "https://cloud.tencent.com/developer/article/write-new",
+    injectFunction: ArticleTencentyun,
+    tags: ["CN"],
+    accountKey: "tencentyun",
   },
   ARTICLE_BAIJIAHAO: {
     type: "ARTICLE",
@@ -358,6 +386,18 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     tags: ["CN"],
     accountKey: "netease",
   },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Sohu ARTICLE DOM fallback 路径
+  ARTICLE_SOHU: {
+    type: "ARTICLE",
+    name: "ARTICLE_SOHU",
+    homeUrl: "https://mp.sohu.com/",
+    faviconUrl: "https://statics.itc.cn/mp-new/icon/1.1/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformSohu"),
+    injectUrl: "https://mp.sohu.com/mpfe/v4/contentManagement/news/addarticle",
+    injectFunction: ArticleSohu,
+    tags: ["CN"],
+    accountKey: "sohu",
+  },
   // experimental(待线上验证):基于 aibeike 1.6.5 的 Dingduanhao ARTICLE DOM 路径
   ARTICLE_DINGDUANHAO: {
     type: "ARTICLE",
@@ -393,5 +433,17 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleYidianzixun,
     tags: ["CN"],
     accountKey: "yidian",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 X Article DOM 路径
+  ARTICLE_XARTICLE: {
+    type: "ARTICLE",
+    name: "ARTICLE_XARTICLE",
+    homeUrl: "https://x.com/compose/articles",
+    faviconUrl: "https://picx.zhimg.com/80/v2-fe30eaa8ebd8c0e49febff8c9bd0d5e4_1440w.png",
+    platformName: chrome.i18n.getMessage("platformX"),
+    injectUrl: "https://x.com/compose/articles",
+    injectFunction: ArticleXArticle,
+    tags: ["International"],
+    accountKey: "x",
   },
 };

--- a/src/sync/article.ts
+++ b/src/sync/article.ts
@@ -4,9 +4,11 @@ import { ArticleBaijiahao } from "./article/baijiahao";
 import { ArticleBilibili } from "./article/bilibili";
 import { ArticleCSDN } from "./article/csdn";
 import { ArticleDingduanhao } from "./article/dingduanhao";
+import { ArticleDongchedi } from "./article/dongchedi";
 import { ArticleDouban } from "./article/douban";
 import { ArticleEastmoney } from "./article/eastmoney";
 import { ArticleInfoQ } from "./article/infoq";
+import { ArticleJianpian } from "./article/jianpian";
 import { ArticleJianshu } from "./article/jianshu";
 import { ArticleJuejin } from "./article/juejin";
 import { ArticleKuaichuanhao } from "./article/kuaichuanhao";
@@ -18,6 +20,7 @@ import { ArticleSegmentfault } from "./article/segmentfault";
 import { ArticleSMZDM } from "./article/smzdm";
 import { ArticleSSPai } from "./article/sspai";
 import { ArticleSubstack } from "./article/substack";
+import { ArticleTonghuashun } from "./article/tonghuashun";
 import { ArticleToutiao } from "./article/toutiao";
 import { ArticleWeibo } from "./article/weibo";
 import { ArticleWeixin } from "./article/weixin";
@@ -26,6 +29,7 @@ import { ArticleWoshipm } from "./article/woshipm";
 import { ArticleXueqiu } from "./article/xueqiu";
 import { ArticleYidianzixun } from "./article/yidianzixun";
 import { ArticleZhihu } from "./article/zhihu";
+import { ArticleZsxq } from "./article/zsxq";
 import type { PlatformInfo } from "./common";
 
 export const ArticleInfoMap: Record<string, PlatformInfo> = {
@@ -293,6 +297,54 @@ export const ArticleInfoMap: Record<string, PlatformInfo> = {
     injectFunction: ArticleAutohome,
     tags: ["CN"],
     accountKey: "autohome",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Jianpian ARTICLE DOM 路径
+  ARTICLE_JIANPIAN: {
+    type: "ARTICLE",
+    name: "ARTICLE_JIANPIAN",
+    homeUrl: "https://www.jianpian.cn/",
+    faviconUrl: "https://ss2.meipian.me/editor-v3/webcdn/logo.ico",
+    platformName: chrome.i18n.getMessage("platformJianpian"),
+    injectUrl: "https://www.jianpian.cn/p/edit",
+    injectFunction: ArticleJianpian,
+    tags: ["CN"],
+    accountKey: "jianpian",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Tonghuashun ARTICLE DOM 路径
+  ARTICLE_TONGHUASHUN: {
+    type: "ARTICLE",
+    name: "ARTICLE_TONGHUASHUN",
+    homeUrl: "https://t.10jqka.com.cn/",
+    faviconUrl: "https://t.10jqka.com.cn/circle/images/favicon.ico",
+    platformName: chrome.i18n.getMessage("platformTonghuashun"),
+    injectUrl: "https://t.10jqka.com.cn/newcircle/creation/postAll",
+    injectFunction: ArticleTonghuashun,
+    tags: ["CN"],
+    accountKey: "tonghuashun",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Dongchedi ARTICLE DOM 路径
+  ARTICLE_DONGCHEDI: {
+    type: "ARTICLE",
+    name: "ARTICLE_DONGCHEDI",
+    homeUrl: "https://mp.dcdapp.com/",
+    faviconUrl: "https://p3-dcd.byteimg.com/obj/tos-cn-i-dcdx/4e214394e186b0a95bc9ab7fc5154770",
+    platformName: chrome.i18n.getMessage("platformDongchedi"),
+    injectUrl: "https://mp.dcdapp.com/profile_v2/publish/article",
+    injectFunction: ArticleDongchedi,
+    tags: ["CN"],
+    accountKey: "dongchedi",
+  },
+  // experimental(待线上验证):基于 aibeike 1.6.5 的 Zsxq ARTICLE DOM 路径
+  ARTICLE_ZSXQ: {
+    type: "ARTICLE",
+    name: "ARTICLE_ZSXQ",
+    homeUrl: "https://wx.zsxq.com/",
+    faviconUrl: "https://wx.zsxq.com/assets_dweb/images/favicon_32.ico",
+    platformName: chrome.i18n.getMessage("platformZSXQ"),
+    injectUrl: "https://wx.zsxq.com/",
+    injectFunction: ArticleZsxq,
+    tags: ["CN"],
+    accountKey: "zsxq",
   },
   // experimental(待线上验证):基于 aibeike 1.6.5 的 163 DOM 路径,正文图片 CDN 重传需后续 API 化
   ARTICLE_NETEASE: {

--- a/src/sync/article/aliyun.ts
+++ b/src/sync/article/aliyun.ts
@@ -1,0 +1,100 @@
+/**
+ * 阿里云文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Aliyun ARTICLE DOM 路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+import type { ArticleData, SyncData } from "~sync/common";
+
+export async function ArticleAliyun(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  function setControlValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+    const prototype =
+      element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      element.value = value;
+    }
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  async function clickPublishButton(): Promise<void> {
+    await sleep(1000);
+    const buttons = Array.from(document.querySelectorAll("button, [role='button']")) as HTMLElement[];
+    const publishButton = buttons.find((element) => {
+      const text = element.textContent?.trim();
+      return text === "发布" || text === "发布文章" || text?.includes("发布文章");
+    });
+    if (publishButton) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else {
+      console.debug("阿里云:未找到发布按钮");
+    }
+  }
+
+  try {
+    // TODO(待线上验证): API path with signed OSS image upload not ported.
+    await waitForElement('input[placeholder="请填写标题"], textarea.textarea');
+    await sleep(1000);
+
+    const titleInput = document.querySelector('input[placeholder="请填写标题"]') as HTMLInputElement | null;
+    if (titleInput) {
+      setControlValue(titleInput, articleData.title || "");
+    } else {
+      console.debug("阿里云:未找到标题输入框");
+    }
+
+    const summaryTextarea = document.querySelector('textarea[placeholder="请填写摘要"]') as HTMLTextAreaElement | null;
+    if (summaryTextarea) {
+      setControlValue(summaryTextarea, articleData.digest || "");
+    }
+
+    const markdownTextarea = document.querySelector("textarea.textarea") as HTMLTextAreaElement | null;
+    if (!markdownTextarea) {
+      console.debug("阿里云:未找到 Markdown 编辑器 textarea");
+      return;
+    }
+
+    markdownTextarea.focus();
+    setControlValue(markdownTextarea, articleData.markdownContent || articleData.htmlContent || "");
+
+    if (data.isAutoPublish === true) {
+      await clickPublishButton();
+    }
+  } catch (error) {
+    console.error("阿里云文章发布出错:", error);
+  }
+}

--- a/src/sync/article/dingduanhao.ts
+++ b/src/sync/article/dingduanhao.ts
@@ -1,0 +1,129 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 顶端号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Dingduanhao ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleDingduanhao(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function uploadCover(): Promise<boolean> {
+    if (!articleData.cover?.url) return true;
+
+    const coverRadio = Array.from(document.querySelectorAll("span.el-radio__label")).find((element) =>
+      element.textContent?.includes("小封面"),
+    ) as HTMLElement | undefined;
+    if (coverRadio) {
+      coverRadio.click();
+      await sleep(1000);
+    }
+
+    const fileInput = document.querySelector("input#upload") as HTMLInputElement | null;
+    if (!fileInput) {
+      console.debug("顶端号:未找到封面上传元素");
+      return false;
+    }
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length > 0) {
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await sleep(3000);
+    }
+
+    return true;
+  }
+
+  try {
+    await waitForElement("input");
+    await sleep(1000);
+
+    const clearButton = document.querySelector("a.oprt") as HTMLElement | null;
+    if (clearButton) {
+      clearButton.click();
+      await sleep(1000);
+    }
+
+    const titleInput = document.querySelector('input[placeholder="请输入标题文字(2-35字)"]') as HTMLInputElement | null;
+    if (titleInput) {
+      titleInput.value = articleData.title?.slice(0, 35) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const summaryTextarea = document.querySelector('textarea[placeholder="请输入摘要"]') as HTMLTextAreaElement | null;
+    if (summaryTextarea) {
+      summaryTextarea.value = articleData.digest?.slice(0, 128) || "";
+      summaryTextarea.dispatchEvent(new Event("input", { bubbles: true }));
+      summaryTextarea.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div[contenteditable="true"]') as HTMLElement | null;
+    if (!editor) {
+      console.debug("顶端号:未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", articleData.htmlContent || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const coverUploaded = await uploadCover();
+    if (!coverUploaded) return;
+
+    const publishButton = document.querySelector(
+      "div.button_publish.item.editor-btn.editor-main-btn",
+    ) as HTMLElement | null;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("顶端号:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("顶端号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/dongchedi.ts
+++ b/src/sync/article/dongchedi.ts
@@ -1,0 +1,142 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 懂车号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Dongchedi ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleDongchedi(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  function findEditorIframe(): HTMLIFrameElement | null {
+    const ueditorIframe = document.querySelector("iframe#ueditor_0") as HTMLIFrameElement | null;
+    if (ueditorIframe) return ueditorIframe;
+
+    const editorIframes = Array.from(document.querySelectorAll('iframe[id^="ueditor_"]')) as HTMLIFrameElement[];
+    if (editorIframes.length > 0) return editorIframes[0];
+
+    const iframeWithEditableBody = Array.from(document.querySelectorAll("iframe")).find((iframe) => {
+      const body = (iframe as HTMLIFrameElement).contentDocument?.body;
+      return Boolean(body?.isContentEditable || body?.className || body?.children.length);
+    }) as HTMLIFrameElement | undefined;
+
+    return iframeWithEditableBody || null;
+  }
+
+  async function uploadCover(): Promise<void> {
+    if (!articleData.cover?.url) return;
+
+    const coverUpload = document.querySelector("div.fake-upload-trigger") as HTMLElement | null;
+    if (!coverUpload) return;
+
+    coverUpload.click();
+    await sleep(1000);
+
+    const localUpload = Array.from(document.querySelectorAll("li")).find((element) =>
+      element.textContent?.includes("本地上传"),
+    ) as HTMLElement | undefined;
+    if (!localUpload) return;
+
+    localUpload.click();
+    await sleep(1000);
+
+    const fileInput = document.querySelector("div.xigua-upload-poster-trigger > input") as HTMLInputElement | null;
+    if (!fileInput) return;
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length === 0) return;
+
+    fileInput.files = dataTransfer.files;
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await sleep(3000);
+
+    const clipButton = document.querySelector("div.clip-btn-content") as HTMLElement | null;
+    if (clipButton) {
+      clipButton.click();
+      await sleep(1000);
+    }
+
+    const doneButton = Array.from(document.querySelectorAll("button")).find((button) => button.textContent === "确定");
+    if (doneButton) {
+      doneButton.click();
+      await sleep(1000);
+
+      const confirmButton = document.querySelector("button.m-button.red") as HTMLButtonElement | null;
+      confirmButton?.click();
+    }
+  }
+
+  try {
+    await waitForElement("textarea");
+    await sleep(1000);
+
+    const titleTextarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+    if (titleTextarea) {
+      titleTextarea.value = articleData.title || "";
+      titleTextarea.dispatchEvent(new Event("input", { bubbles: true }));
+      titleTextarea.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    await waitForElement("iframe");
+    const editorIframe = findEditorIframe();
+    const editorBody = editorIframe?.contentDocument?.body;
+    if (!editorBody) {
+      console.debug("懂车号:未找到编辑器 iframe");
+      return;
+    }
+
+    editorBody.innerHTML = articleData.htmlContent || "";
+    editorBody.dispatchEvent(new Event("input", { bubbles: true }));
+    editorBody.dispatchEvent(new Event("change", { bubbles: true }));
+    await sleep(3000);
+
+    await uploadCover();
+
+    const publishButton = Array.from(document.querySelectorAll("button.publish-btn")).find((button) =>
+      button.textContent?.includes("预览并发布"),
+    ) as HTMLButtonElement | undefined;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("懂车号:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("懂车号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/jianpian.ts
+++ b/src/sync/article/jianpian.ts
@@ -1,0 +1,100 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 美篇/简篇文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Jianpian ARTICLE DOM 路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleJianpian(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function waitForContentEditor(titleEditor: HTMLElement, timeout = 15000): Promise<HTMLElement | null> {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeout) {
+      const editors = Array.from(document.querySelectorAll("div[contenteditable='true']")) as HTMLElement[];
+      const editor = editors.find((element) => element !== titleEditor);
+      if (editor) return editor;
+      await sleep(500);
+    }
+
+    return null;
+  }
+
+  function pasteHtml(editor: HTMLElement, html: string) {
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", html);
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  try {
+    const titleEditor = (await waitForElement(
+      "div[contenteditable='true'][data-placeholder='点击添加标题']",
+    )) as HTMLElement;
+    await sleep(1000);
+
+    titleEditor.focus();
+    titleEditor.innerText = articleData.title || "";
+    titleEditor.dispatchEvent(new Event("input", { bubbles: true }));
+    titleEditor.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const contentEditor = await waitForContentEditor(titleEditor);
+    if (!contentEditor) {
+      console.debug("美篇/简篇:未找到正文编辑器元素");
+      return;
+    }
+
+    pasteHtml(contentEditor, articleData.htmlContent || "");
+    await sleep(3000);
+
+    // TODO: aibeike 参考实现包含 Word 文档导入路径,MultiPost ArticleData 暂无 wordFileData,此处仅保留 HTML 粘贴路径。
+    if (data.isAutoPublish === true) {
+      const publishButton = Array.from(document.querySelectorAll("button, [role='button']")).find((element) =>
+        element.textContent?.includes("发布"),
+      ) as HTMLElement | undefined;
+      if (publishButton) {
+        publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+      } else {
+        console.debug("美篇/简篇:未找到发布按钮");
+      }
+    }
+  } catch (error) {
+    console.error("美篇/简篇文章发布出错:", error);
+  }
+}

--- a/src/sync/article/kuaichuanhao.ts
+++ b/src/sync/article/kuaichuanhao.ts
@@ -1,0 +1,111 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 快传号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Kuaichuanhao ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleKuaichuanhao(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function uploadCover(): Promise<boolean> {
+    if (!articleData.cover?.url) return true;
+
+    const fileInput = document.querySelector(
+      'input[type="file"][accept="image/*"][class="preview__input"]',
+    ) as HTMLInputElement | null;
+    if (!fileInput) {
+      console.debug("快传号:未找到封面上传元素");
+      return false;
+    }
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length > 0) {
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await sleep(3000);
+    }
+
+    return true;
+  }
+
+  try {
+    await waitForElement("textarea");
+    await sleep(1000);
+
+    const titleTextarea = document.querySelector("textarea[placeholder='请输入标题']") as HTMLTextAreaElement | null;
+    if (titleTextarea) {
+      titleTextarea.value = articleData.title?.slice(0, 40) || "";
+      titleTextarea.dispatchEvent(new Event("input", { bubbles: true }));
+      titleTextarea.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div[contenteditable="true"]') as HTMLElement | null;
+    if (!editor) {
+      console.debug("快传号:未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", articleData.htmlContent || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.innerHTML = articleData.htmlContent || "";
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const coverUploaded = await uploadCover();
+    if (!coverUploaded) return;
+
+    const publishButton = document.querySelector(
+      "div.button_publish.item.editor-btn.editor-main-btn",
+    ) as HTMLElement | null;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("快传号:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("快传号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/netease.ts
+++ b/src/sync/article/netease.ts
@@ -1,0 +1,98 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 网易号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 163 DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ *
+ * 仅做 DOM 填充(标题 + 正文 paste + 封面自动 + 门控发布),不做正文图片的平台 CDN 重传——
+ * 后者依赖页面内的 wemediaId / realUserId 凭证(aibeike 硬编码了其自有账号,对其他用户无效),
+ * 属后续 API 化工作。
+ */
+export async function ArticleNetease(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const exist = document.querySelector(selector);
+      if (exist) {
+        resolve(exist);
+        return;
+      }
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`元素 "${selector}" 在 ${timeout}ms 内未出现`));
+      }, timeout);
+    });
+  }
+
+  // 网易号编辑器最高支持到 h5:把 h1-h4/h6 统一降级为 h5,避免标题样式丢失
+  function normalizeHeadings(html: string): string {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    for (const heading of Array.from(doc.querySelectorAll("h1,h2,h3,h4,h6"))) {
+      const h5 = document.createElement("h5");
+      h5.innerHTML = heading.innerHTML;
+      heading.parentNode?.replaceChild(h5, heading);
+    }
+    return doc.body.innerHTML;
+  }
+
+  try {
+    // 标题(网易号限制 5~30 字)
+    const titleInput = (await waitForElement('textarea[placeholder="请输入标题 (5~30个字)"]')) as HTMLTextAreaElement;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    if (titleInput) {
+      titleInput.value = articleData.title?.slice(0, 30) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    // 正文:网易号使用 Draft.js 编辑器(data-contents),通过 paste 注入 HTML
+    const editor = (await waitForElement('div[data-contents="true"]')) as HTMLElement;
+    if (!editor) {
+      console.error("网易号:未找到正文编辑器");
+      return;
+    }
+    editor.focus();
+    const paste = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    paste.clipboardData?.setData("text/html", normalizeHeadings(articleData.htmlContent || ""));
+    editor.dispatchEvent(paste);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // 封面设为"自动"
+    const autoCover = Array.from(document.querySelectorAll("span.ne-switch-base-label-text")).find(
+      (span) => span.textContent?.trim() === "自动",
+    ) as HTMLElement | undefined;
+    autoCover?.click();
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // 仅在用户开启自动发布时点击"发布";否则留给用户手动确认
+    if (data.isAutoPublish === true) {
+      const publishButton = Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === "发布",
+      ) as HTMLButtonElement | undefined;
+      if (publishButton) {
+        publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+      } else {
+        console.debug("网易号:未找到'发布'按钮");
+      }
+    }
+  } catch (error) {
+    console.error("网易号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/qq.ts
+++ b/src/sync/article/qq.ts
@@ -1,0 +1,164 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 企鹅号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 QQ ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleQQ(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function uploadCover(): Promise<void> {
+    if (!articleData.cover?.url) return;
+
+    const coverRadio = Array.from(document.querySelectorAll("span.omui-radio__label")).find((element) =>
+      element.textContent?.includes("单图"),
+    ) as HTMLElement | undefined;
+    if (!coverRadio) {
+      console.debug("企鹅号:未找到单图封面选项");
+      return;
+    }
+
+    coverRadio.click();
+    await sleep(1000);
+
+    const replaceCover = Array.from(
+      document.querySelectorAll("figure.omui-thumb__figure > div.omui-thumb__action > span"),
+    ).find((element) => element.textContent === "更换") as HTMLElement | undefined;
+    const addCover = coverRadio.parentElement?.parentElement?.nextElementSibling?.querySelector(
+      "button > i.omui-icon-plus",
+    ) as HTMLElement | null;
+    const uploadImageButton = replaceCover || addCover;
+    if (!uploadImageButton) {
+      console.debug("企鹅号:未找到封面上传按钮");
+      return;
+    }
+
+    uploadImageButton.click();
+    await sleep(1000);
+
+    const uploadTab = Array.from(document.querySelectorAll("li.omui-tab__label")).find((element) =>
+      element.textContent?.includes("本地上传"),
+    ) as HTMLElement | undefined;
+    if (!uploadTab) {
+      console.debug("企鹅号:未找到本地上传标签");
+      return;
+    }
+
+    uploadTab.click();
+    await sleep(1000);
+
+    const fileInput = document.querySelector(
+      'input[type="file"][accept="image/png,image/jpg,image/jpeg,image/heic,image/heif"]',
+    ) as HTMLInputElement | null;
+    if (!fileInput) {
+      console.debug("企鹅号:未找到封面文件输入框");
+      return;
+    }
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length > 0) {
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    await sleep(3000);
+
+    const confirmButton = Array.from(document.querySelectorAll("button.omui-button--primary.omui-button--sm")).find(
+      (button) => button.textContent?.includes("确认"),
+    ) as HTMLButtonElement | undefined;
+    while (confirmButton?.disabled) {
+      await sleep(1000);
+    }
+    if (confirmButton && !confirmButton.disabled) {
+      confirmButton.click();
+      await sleep(1000);
+    }
+  }
+
+  try {
+    await waitForElement('span[data-placeholder="请输入标题（5-64个字）"]');
+    await sleep(1000);
+
+    const countdownTip = document.querySelector('div[class="omui-countdowntip"][_nk="uezG11"]');
+    const cancelButton = countdownTip?.querySelector("a") as HTMLElement | null;
+    if (cancelButton) {
+      cancelButton.click();
+      await sleep(3000);
+    }
+
+    const titleInput = document.querySelector('span[data-placeholder="请输入标题（5-64个字）"]') as HTMLElement | null;
+    if (titleInput) {
+      titleInput.innerHTML = articleData.title?.slice(0, 64) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div.ProseMirror[contenteditable="true"]') as HTMLElement | null;
+    if (!editor) {
+      console.debug("企鹅号:未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", articleData.htmlContent || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+    await sleep(5000);
+
+    await uploadCover();
+
+    const publishButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent === "发布",
+    ) as HTMLButtonElement | undefined;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.click();
+    } else if (!publishButton) {
+      console.debug("企鹅号:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("企鹅号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/sohu.ts
+++ b/src/sync/article/sohu.ts
@@ -1,0 +1,100 @@
+/**
+ * 搜狐号文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Sohu ARTICLE DOM fallback 路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+import type { ArticleData, SyncData } from "~sync/common";
+
+export async function ArticleSohu(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  function setControlValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+    const prototype =
+      element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      element.value = value;
+    }
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function clickPublishButton(): void {
+    const candidates = Array.from(
+      document.querySelectorAll("li.positive-button, button, [role='button']"),
+    ) as HTMLElement[];
+    const publishButton = candidates.find((element) => element.textContent?.trim().includes("发布"));
+    if (publishButton) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else {
+      console.debug("搜狐号:未找到发布按钮");
+    }
+  }
+
+  try {
+    // TODO(待线上验证): Draft/image API path with Sohu auth headers not ported.
+    await waitForElement('div[contenteditable="true"], div.ql-editor');
+    await sleep(2000);
+
+    const titleInput = document.querySelector(
+      'input[placeholder="请输入标题（5-72字）"], input[placeholder*="标题"], textarea[placeholder*="标题"]',
+    ) as HTMLInputElement | HTMLTextAreaElement | null;
+    if (titleInput) {
+      setControlValue(titleInput, articleData.title?.slice(0, 72) || "");
+    } else {
+      console.debug("搜狐号:未找到标题输入框");
+    }
+
+    const editor = document.querySelector(
+      'div.ql-editor[contenteditable="true"], div.ql-editor, div[contenteditable="true"]',
+    ) as HTMLElement | null;
+    if (!editor) {
+      console.debug("搜狐号:未找到 Quill 编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    editor.innerHTML = articleData.htmlContent || "";
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+    await sleep(5000);
+
+    if (data.isAutoPublish === true) {
+      clickPublishButton();
+    }
+  } catch (error) {
+    console.error("搜狐号文章发布出错:", error);
+  }
+}

--- a/src/sync/article/tencentyun.ts
+++ b/src/sync/article/tencentyun.ts
@@ -1,0 +1,145 @@
+/**
+ * 腾讯云文章发布(experimental,待线上验证)
+ *
+ * aibeike 1.6.5 的 TencentYun ARTICLE 实现主要走 COS 签名上传 + 草稿 API。本实现按策略仅保留
+ * DOM 填充路径。本环境无法登录目标平台验证,选择器/流程需线上回归。
+ */
+import type { ArticleData, SyncData } from "~sync/common";
+
+export async function ArticleTencentyun(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  function setControlValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+    const prototype =
+      element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      element.value = value;
+    }
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function findMarkdownTextarea(): HTMLTextAreaElement | null {
+    const textareas = Array.from(document.querySelectorAll("textarea")) as HTMLTextAreaElement[];
+    return (
+      textareas.find((textarea) => textarea.classList.contains("textarea")) ||
+      textareas.find((textarea) => {
+        const placeholder = textarea.placeholder || "";
+        return !placeholder.includes("标题") && !placeholder.includes("摘要") && textarea.clientHeight >= 80;
+      }) ||
+      null
+    );
+  }
+
+  async function fillFallbackEditor(content: string): Promise<boolean> {
+    const editor = document.querySelector(
+      '.CodeMirror-code[role="presentation"], .monaco-editor textarea, [contenteditable="true"]',
+    ) as HTMLElement | HTMLTextAreaElement | null;
+    if (!editor) return false;
+
+    editor.focus();
+    if (editor instanceof HTMLTextAreaElement) {
+      setControlValue(editor, content);
+    } else {
+      const pasteEvent = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: new DataTransfer(),
+      });
+      pasteEvent.clipboardData?.setData("text/plain", content);
+      editor.dispatchEvent(pasteEvent);
+      editor.dispatchEvent(new Event("input", { bubbles: true }));
+      editor.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    return true;
+  }
+
+  async function clickPublishButton(): Promise<void> {
+    await sleep(1000);
+    const buttons = Array.from(document.querySelectorAll("button, [role='button']")) as HTMLElement[];
+    const publishButton = buttons.find((element) => {
+      const text = element.textContent?.trim();
+      return text === "发布" || text === "发布文章" || text?.includes("发布文章");
+    });
+    if (publishButton) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else {
+      console.debug("腾讯云:未找到发布按钮");
+    }
+  }
+
+  try {
+    // TODO(待线上验证): API path with signed COS upload and draft API not ported.
+    await waitForElement('input[placeholder*="标题"], textarea[placeholder*="标题"], textarea');
+    await sleep(1000);
+
+    const titleInput = document.querySelector('input[placeholder*="标题"], textarea[placeholder*="标题"]') as
+      | HTMLInputElement
+      | HTMLTextAreaElement
+      | null;
+    if (titleInput) {
+      setControlValue(titleInput, articleData.title || "");
+    } else {
+      console.debug("腾讯云:未找到标题输入框");
+    }
+
+    const summaryInput = document.querySelector('textarea[placeholder*="摘要"], input[placeholder*="摘要"]') as
+      | HTMLInputElement
+      | HTMLTextAreaElement
+      | null;
+    if (summaryInput) {
+      setControlValue(summaryInput, articleData.digest || "");
+    }
+
+    const content = articleData.markdownContent || articleData.htmlContent || "";
+    const markdownTextarea = findMarkdownTextarea();
+    if (markdownTextarea) {
+      markdownTextarea.focus();
+      setControlValue(markdownTextarea, content);
+    } else {
+      const filledFallback = await fillFallbackEditor(content);
+      if (!filledFallback) {
+        console.debug("腾讯云:未找到 Markdown 编辑器");
+        return;
+      }
+    }
+
+    if (data.isAutoPublish === true) {
+      await clickPublishButton();
+    }
+  } catch (error) {
+    console.error("腾讯云文章发布出错:", error);
+  }
+}

--- a/src/sync/article/tonghuashun.ts
+++ b/src/sync/article/tonghuashun.ts
@@ -1,0 +1,141 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 同花顺文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Tonghuashun ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleTonghuashun(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function uploadCover(): Promise<void> {
+    if (!articleData.cover?.url) return;
+
+    const selectFromLibrary = document.querySelector("div.select-from-library") as HTMLElement | null;
+    if (!selectFromLibrary) {
+      console.debug("同花顺:未找到图库选择入口");
+      return;
+    }
+
+    selectFromLibrary.click();
+    await sleep(1000);
+
+    const fileInput = document.querySelector("input#upfile") as HTMLInputElement | null;
+    if (!fileInput) {
+      console.debug("同花顺:未找到封面上传元素");
+      return;
+    }
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length > 0) {
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await sleep(5000);
+    }
+
+    const checkList = document.querySelector("ul.check-list.clearfix");
+    const firstItem = checkList?.querySelector("li") as HTMLElement | null;
+    if (!firstItem) return;
+
+    firstItem.click();
+    await sleep(1000);
+
+    const confirmButton = document.querySelector(
+      "div.modify-comfirm-btn.dib.lightgraybg.coolbluebg",
+    ) as HTMLElement | null;
+    if (!confirmButton) return;
+
+    confirmButton.click();
+    await sleep(3000);
+
+    const sureButton = document.querySelector("div.D-crop-opera-sure.btn.coolbluebg") as HTMLElement | null;
+    if (sureButton) {
+      sureButton.click();
+      await sleep(1000);
+    }
+  }
+
+  try {
+    await waitForElement("i.icon-editpost.icon-editpost-add");
+    await sleep(1000);
+
+    const newArticleButton = document.querySelector("i.icon-editpost.icon-editpost-add") as HTMLElement | null;
+    if (newArticleButton) {
+      newArticleButton.click();
+      await sleep(1000);
+    }
+
+    const titleInput = document.querySelector("input#edui1-title") as HTMLInputElement | null;
+    if (titleInput) {
+      titleInput.value = articleData.title?.slice(0, 36) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editorIframe = document.getElementById("ueditor_0") as HTMLIFrameElement | null;
+    const editorBody = editorIframe?.contentDocument?.body;
+    if (!editorBody) {
+      console.debug("同花顺:未找到编辑器 iframe");
+      return;
+    }
+
+    editorBody.innerHTML = articleData.htmlContent || "";
+    editorBody.dispatchEvent(new Event("input", { bubbles: true }));
+    editorBody.dispatchEvent(new Event("change", { bubbles: true }));
+    await sleep(3000);
+
+    const nextButton = document.querySelector('a[data-statid="sns_work_desktop.editor.next"]') as HTMLElement | null;
+    if (nextButton) {
+      nextButton.click();
+      await sleep(1000);
+      await uploadCover();
+    }
+
+    const publishButton = document.querySelector(
+      "div.button_publish.item.editor-btn.editor-main-btn",
+    ) as HTMLElement | null;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("同花顺:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("同花顺文章发布出错:", error);
+  }
+}

--- a/src/sync/article/weibo.ts
+++ b/src/sync/article/weibo.ts
@@ -60,7 +60,7 @@ export async function ArticleWeibo(data: SyncData) {
   }
 
   // 上传图片
-  async function uploadImage(fileInfo: FileData): Promise<string | null> {
+  async function uploadImage(fileInfo: FileData): Promise<{ pid: string; width: number; height: number } | null> {
     console.debug("uploadImage", fileInfo);
 
     const uploadUrl = new URL("https://picupload.weibo.com/interface/pic_upload.php");
@@ -90,8 +90,9 @@ export async function ArticleWeibo(data: SyncData) {
       const result = await response.json();
       console.debug("Image upload result:", result);
 
-      if (result?.data?.pics?.pic_1?.pid) {
-        return `https://wx2.sinaimg.cn/large/${result.data.pics.pic_1.pid}.jpg`;
+      const pic = result?.data?.pics?.pic_1;
+      if (pic?.pid) {
+        return { pid: pic.pid, width: Number(pic.width) || 0, height: Number(pic.height) || 0 };
       }
       return null;
     } catch (error) {
@@ -122,10 +123,27 @@ export async function ArticleWeibo(data: SyncData) {
         const fileInfo = imageFiles.find((f) => f.url === src);
 
         if (fileInfo) {
-          const newUrl = await uploadImage(fileInfo);
-          if (newUrl) {
-            img.setAttribute("src", newUrl);
-            console.debug("newUrl", newUrl);
+          const uploaded = await uploadImage(fileInfo);
+          if (uploaded) {
+            const { pid, width, height } = uploaded;
+            // 包成微博图文标准的 figure+srcset 结构以提升多分辨率渲染;src 仍为 large,srcset 失效也不影响展示
+            const figure = doc.createElement("figure");
+            figure.className = "image";
+            const newImg = doc.createElement("img");
+            newImg.setAttribute("src", `https://wx2.sinaimg.cn/large/${pid}.jpg`);
+            newImg.setAttribute("alt", "图片");
+            newImg.setAttribute(
+              "srcset",
+              `https://wx2.sinaimg.cn/bmiddle/${pid}.jpg 440w, https://wx2.sinaimg.cn/mw690/${pid}.jpg 690w, https://wx2.sinaimg.cn/mw1024/${pid}.jpg 1024w, https://wx2.sinaimg.cn/large/${pid}.jpg 2048w`,
+            );
+            newImg.setAttribute("sizes", "100vw");
+            if (width && height) {
+              newImg.setAttribute("aspect", (width / height).toString());
+              newImg.setAttribute("width", width.toString());
+            }
+            figure.appendChild(newImg);
+            img.replaceWith(figure);
+            console.debug("newUrl", `https://wx2.sinaimg.cn/large/${pid}.jpg`);
           }
         }
       }
@@ -300,41 +318,43 @@ export async function ArticleWeibo(data: SyncData) {
         // 处理文章内容中的图片
         articleData.htmlContent = await processContent(articleData.htmlContent, articleData.images || [], updateTip);
 
-        // 处理封面图片
-        updateTip("正在上传封面...");
+        // 处理封面图片(可选):无封面时此前会整篇不发布,现修复为封面缺省也照常发布
+        let coverUrl: string | null = null;
         if (articleData.cover) {
+          updateTip("正在上传封面...");
           const croppedCover = await cropImage(articleData.cover, 16 / 9);
-          const coverUrl = await uploadImage(croppedCover);
-
-          if (!coverUrl) {
+          const uploaded = await uploadImage(croppedCover);
+          if (uploaded) {
+            coverUrl = `https://wx2.sinaimg.cn/large/${uploaded.pid}.jpg`;
+          } else {
             console.debug("封面上传失败");
           }
-
-          // 创建并保存草稿
-          const draftId = await createAndSaveDraft(articleData, coverUrl, updateTip);
-
-          if (draftId) {
-            updateTip("草稿发布成功，请预览...");
-
-            if (!data.isAutoPublish) {
-              const draftUrl = "https://card.weibo.com/article/v3/editor";
-              console.debug("draftUrl", draftUrl);
-              window.location.href = draftUrl;
-            }
-            return true;
-          }
-          updateTip("尝试 DOM 发布...");
-          // 这里可以添加DOM发布的逻辑
-          updateTip("请继续操作...");
-          return false;
         }
+
+        // 创建并保存草稿(无论是否有封面)
+        const draftId = await createAndSaveDraft(articleData, coverUrl, updateTip);
+
+        if (draftId) {
+          updateTip("草稿发布成功，请预览...");
+
+          if (!data.isAutoPublish) {
+            const draftUrl = "https://card.weibo.com/article/v3/editor";
+            console.debug("draftUrl", draftUrl);
+            window.location.href = draftUrl;
+          }
+          return true;
+        }
+
+        // TODO(待线上验证): 草稿 API 失败时的 DOM 兜底发布尚未实现;参考 aibeike weibo.js b13
+        updateTip("草稿创建失败，请手动操作");
+        return false;
       } catch (error) {
         console.error("发布文章失败:", error);
         return false;
       }
     }
 
-    publishToWeibo();
+    await publishToWeibo();
 
     // 3秒后移除提示
     setTimeout(() => {

--- a/src/sync/article/xarticle.ts
+++ b/src/sync/article/xarticle.ts
@@ -1,0 +1,180 @@
+/**
+ * X 长文发布(experimental,待线上验证)
+ *
+ * aibeike 1.6.5 的 X ARTICLE 分支包含 GraphQL 草稿 API。本实现按策略仅保留 X Articles 页面
+ * 的 DOM 填充路径。本环境无法登录目标平台验证,选择器/流程需线上回归。
+ */
+import type { ArticleData, SyncData } from "~sync/common";
+
+export async function ArticleXArticle(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  function setControlValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): void {
+    const prototype =
+      element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const valueSetter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      element.value = value;
+    }
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function textMatches(element: Element, keywords: string[]): boolean {
+    const ariaLabel = element.getAttribute("aria-label") || "";
+    const placeholder = element.getAttribute("placeholder") || "";
+    const testId = element.getAttribute("data-testid") || "";
+    const joined = `${ariaLabel} ${placeholder} ${testId}`.toLowerCase();
+    return keywords.some((keyword) => joined.includes(keyword.toLowerCase()));
+  }
+
+  function findTitleElement(): HTMLElement | HTMLInputElement | HTMLTextAreaElement | null {
+    const directTitle = document.querySelector(
+      'input[placeholder*="Title"], textarea[placeholder*="Title"], input[placeholder*="标题"], textarea[placeholder*="标题"], [contenteditable="true"][aria-label*="Title"], [contenteditable="true"][aria-label*="标题"]',
+    ) as HTMLElement | HTMLInputElement | HTMLTextAreaElement | null;
+    if (directTitle) return directTitle;
+
+    const editables = Array.from(document.querySelectorAll('[contenteditable="true"], div[data-contents="true"]'));
+    return (
+      (editables.find((element) => textMatches(element, ["title", "标题"])) as HTMLElement | undefined) ||
+      ((editables.length > 1 ? editables[0] : null) as HTMLElement | null) ||
+      null
+    );
+  }
+
+  function findBodyElement(titleElement: Element | null): HTMLElement | null {
+    const directBody = document.querySelector(
+      'div[data-contents="true"], [contenteditable="true"][aria-label*="Body"], [contenteditable="true"][aria-label*="article"], [contenteditable="true"][aria-label*="正文"]',
+    ) as HTMLElement | null;
+    if (directBody && directBody !== titleElement) return directBody;
+
+    const editables = Array.from(document.querySelectorAll('[contenteditable="true"], div[data-contents="true"]'));
+    return (
+      (editables.find((element) => element !== titleElement && !textMatches(element, ["title", "标题"])) as
+        | HTMLElement
+        | undefined) || null
+    );
+  }
+
+  function fillEditableText(element: HTMLElement, value: string): void {
+    element.focus();
+    element.textContent = value;
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  function pasteHtml(element: HTMLElement, html: string): void {
+    element.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", html);
+    pasteEvent.clipboardData?.setData("text/plain", html);
+    element.dispatchEvent(pasteEvent);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  async function clickPublishButton(bodyElement: HTMLElement): Promise<void> {
+    await sleep(3000);
+    const buttons = Array.from(document.querySelectorAll("button, [role='button']")) as HTMLButtonElement[];
+    const publishButton = buttons.find((button) => {
+      const text = button.textContent?.trim();
+      return text === "Post" || text === "Publish" || text === "发帖" || text === "发布" || text === "發佈";
+    });
+
+    if (publishButton) {
+      let attempts = 0;
+      while (publishButton.disabled && attempts < 10) {
+        await sleep(3000);
+        attempts++;
+      }
+
+      if (!publishButton.disabled) {
+        publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+      } else {
+        console.debug("X 长文:发布按钮仍不可用");
+      }
+      return;
+    }
+
+    const isMac = /Mac|macOS|iPhone|iPod|iPad/.test(navigator.userAgent);
+    const keyEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      composed: true,
+    });
+    bodyElement.focus();
+    bodyElement.dispatchEvent(keyEvent);
+  }
+
+  try {
+    // TODO(待线上验证): GraphQL draft API and signed media upload not ported.
+    await waitForElement(
+      '[contenteditable="true"], div[data-contents="true"], input[placeholder*="Title"], textarea[placeholder*="Title"], input[placeholder*="标题"], textarea[placeholder*="标题"]',
+    );
+    await sleep(1000);
+
+    const titleElement = findTitleElement();
+    if (titleElement instanceof HTMLInputElement || titleElement instanceof HTMLTextAreaElement) {
+      setControlValue(titleElement, articleData.title || "");
+    } else if (titleElement) {
+      fillEditableText(titleElement, articleData.title || "");
+    } else {
+      console.debug("X 长文:未找到标题输入框");
+    }
+
+    const bodyElement = findBodyElement(titleElement);
+    if (!bodyElement) {
+      console.debug("X 长文:未找到正文编辑器");
+      return;
+    }
+
+    pasteHtml(bodyElement, articleData.htmlContent || "");
+
+    if (data.isAutoPublish === true) {
+      await clickPublishButton(bodyElement);
+    }
+  } catch (error) {
+    console.error("X 长文发布出错:", error);
+  }
+}

--- a/src/sync/article/yidianzixun.ts
+++ b/src/sync/article/yidianzixun.ts
@@ -1,0 +1,114 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 一点资讯文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Yidianzixun ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleYidianzixun(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  async function uploadCover(): Promise<boolean> {
+    if (!articleData.cover?.url) return true;
+
+    const fileInput = document.querySelector("input.upload-input-not-found") as HTMLInputElement | null;
+    if (!fileInput) {
+      console.debug("一点资讯:未找到封面上传元素");
+      return false;
+    }
+
+    const dataTransfer = new DataTransfer();
+    const response = await fetch(articleData.cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const file = new File([arrayBuffer], articleData.cover.name, { type: articleData.cover.type });
+    dataTransfer.items.add(file);
+
+    if (dataTransfer.files.length > 0) {
+      fileInput.files = dataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await sleep(3000);
+    }
+
+    return true;
+  }
+
+  try {
+    await waitForElement("input.post-title");
+    await sleep(1000);
+
+    const clearButton = document.querySelector("a.oprt") as HTMLElement | null;
+    if (clearButton) {
+      clearButton.click();
+      await sleep(1000);
+    }
+
+    const titleInput = document.querySelector("input.post-title") as HTMLInputElement | null;
+    if (titleInput) {
+      titleInput.value = articleData.title?.slice(0, 64) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div.editor-content[contenteditable="true"]') as HTMLElement | null;
+    if (!editor) {
+      console.debug("一点资讯:未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", articleData.htmlContent || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const coverUploaded = await uploadCover();
+    if (!coverUploaded) return;
+
+    const publishButton = document.querySelector(
+      "div.button_publish.item.editor-btn.editor-main-btn",
+    ) as HTMLElement | null;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("一点资讯:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("一点资讯文章发布出错:", error);
+  }
+}

--- a/src/sync/article/zsxq.ts
+++ b/src/sync/article/zsxq.ts
@@ -1,0 +1,81 @@
+import type { ArticleData, SyncData } from "~sync/common";
+
+/**
+ * 知识星球文章发布(experimental,待线上验证)
+ *
+ * 基于 aibeike 1.6.5 的 Zsxq ARTICLE DOM 发布路径实现。本环境无法登录目标平台验证,
+ * 选择器/流程以参考实现为准,需线上回归。
+ */
+export async function ArticleZsxq(data: SyncData) {
+  const articleData = data.data as ArticleData;
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const element = document.querySelector(selector);
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`Element with selector "${selector}" not found within ${timeout}ms`));
+      }, timeout);
+    });
+  }
+
+  try {
+    await waitForElement('div[contenteditable="true"]');
+    await sleep(1000);
+
+    const titleInput = document.querySelector('input[placeholder="请在这里输入标题"]') as HTMLInputElement | null;
+    if (titleInput) {
+      titleInput.value = articleData.title?.slice(0, 60) || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div[contenteditable="true"]') as HTMLElement | null;
+    if (!editor) {
+      console.debug("知识星球:未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/html", articleData.htmlContent || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+    await sleep(5000);
+
+    const publishButton = Array.from(document.querySelectorAll("div.post.btn")).find(
+      (element) => element.textContent?.trim() === "发布",
+    ) as HTMLElement | undefined;
+    if (publishButton && data.isAutoPublish === true) {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+    } else if (!publishButton) {
+      console.debug("知识星球:未找到发布按钮");
+    }
+  } catch (error) {
+    console.error("知识星球文章发布出错:", error);
+  }
+}

--- a/src/sync/dynamic.ts
+++ b/src/sync/dynamic.ts
@@ -12,6 +12,7 @@ import { DynamicKuaishou } from "./dynamic/kuaishou";
 import { DynamicLinkedin } from "./dynamic/linkedin";
 import { DynamicMaimai } from "./dynamic/maimai";
 import { DynamicOkjike } from "./dynamic/okjike";
+import { DynamicPinterest } from "./dynamic/pinterest";
 import { DynamicReddit } from "./dynamic/reddit";
 import { DynamicRednote } from "./dynamic/rednote";
 import { DynamicSubstack } from "./dynamic/substack";
@@ -167,6 +168,17 @@ export const DynamicInfoMap: Record<string, PlatformInfo> = {
     injectFunction: DynamicReddit,
     tags: ["International"],
     accountKey: "reddit",
+  },
+  DYNAMIC_PINTEREST: {
+    type: "DYNAMIC",
+    name: "DYNAMIC_PINTEREST",
+    homeUrl: "https://www.pinterest.com/",
+    faviconUrl: "https://s.pinimg.com/webapp/favicon_48x48-7470a30d.png",
+    platformName: chrome.i18n.getMessage("platformPinterest"),
+    injectUrl: "https://www.pinterest.com/pin-creation-tool/",
+    injectFunction: DynamicPinterest,
+    tags: ["International"],
+    accountKey: "pinterest",
   },
   DYNAMIC_KUAISHOU: {
     type: "DYNAMIC",

--- a/src/sync/dynamic/pinterest.ts
+++ b/src/sync/dynamic/pinterest.ts
@@ -1,0 +1,103 @@
+// Experimental publisher (待线上验证)
+import type { DynamicData, SyncData } from "~sync/common";
+
+export async function DynamicPinterest(data: SyncData) {
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const exist = document.querySelector(selector);
+      if (exist) {
+        resolve(exist);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`元素 "${selector}" 在 ${timeout}ms 内未出现`));
+      }, timeout);
+    });
+  }
+
+  function sleep(timeout: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, timeout));
+  }
+
+  try {
+    const { title, content, images } = data.data as DynamicData;
+
+    await waitForElement("input#storyboard-upload-input");
+    if (images.length > 0) {
+      const fileInputs = document.querySelectorAll('input#storyboard-upload-input[type="file"]');
+      console.debug("fileInputs", fileInputs);
+      if (!fileInputs.length) {
+        console.debug("未找到文件输入元素");
+        return;
+      }
+
+      const fileInput = fileInputs[fileInputs.length - 1] as HTMLInputElement;
+      const fileDataTransfer = new DataTransfer();
+      for (const image of images) {
+        console.debug("try upload file", image);
+        const response = await fetch(image.url);
+        const arrayBuffer = await response.arrayBuffer();
+        const file = new File([arrayBuffer], image.name, { type: image.type });
+        fileDataTransfer.items.add(file);
+      }
+
+      fileInput.files = fileDataTransfer.files;
+      fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+      console.debug("文件上传操作完成");
+    }
+
+    await waitForElement("input#storyboard-selector-title:not(:disabled)");
+    const titleInput = document.querySelector(
+      "input#storyboard-selector-title:not(:disabled)",
+    ) as HTMLInputElement | null;
+    console.debug("titleInput", titleInput);
+    if (titleInput) {
+      titleInput.value = title || "";
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div[contenteditable="true"]') as HTMLElement | null;
+    console.debug("qlEditor", editor);
+    if (!editor) {
+      console.debug("未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/plain", content || "");
+    editor.dispatchEvent(pasteEvent);
+    await sleep(1000);
+
+    const sendButton = document.querySelector(
+      'div[data-test-id="storyboard-creation-nav-done"] button',
+    ) as HTMLElement | null;
+    console.debug("sendButton", sendButton);
+    if (sendButton) {
+      if (data.isAutoPublish === true) {
+        console.debug("sendButton clicked");
+        sendButton.dispatchEvent(new Event("click", { bubbles: true }));
+      }
+    } else {
+      console.debug("未找到'发送'按钮");
+    }
+  } catch (error) {
+    console.error("Pinterest 动态发布失败:", error);
+  }
+}

--- a/src/sync/podcast.ts
+++ b/src/sync/podcast.ts
@@ -3,6 +3,7 @@ import { PodcastLiZhi } from "./podcast/lizhi";
 import { PodcastNetease } from "./podcast/netease";
 import { PodcastQingting } from "./podcast/qingting";
 import { PodcastQQMusic } from "./podcast/qqmusic";
+import { PodcastSpotify } from "./podcast/spotify";
 import { PodcastXiaoyuzhou } from "./podcast/xiaoyuzhou";
 import { PodcastXimalaya } from "./podcast/ximalaya";
 
@@ -72,5 +73,16 @@ export const PodcastInfoMap: Record<string, PlatformInfo> = {
     injectFunction: PodcastNetease,
     tags: ["CN"],
     accountKey: "neteasepodcast",
+  },
+  PODCAST_SPOTIFY: {
+    type: "PODCAST",
+    name: "PODCAST_SPOTIFY",
+    homeUrl: "https://creators.spotify.com/",
+    faviconUrl: "https://cdnv2.ruguoapp.com/FoKl7osSH8MdbCtJ799pJwpUx3amv3.png",
+    platformName: chrome.i18n.getMessage("platformSpotify"),
+    injectUrl: "https://creators.spotify.com/pod/show",
+    injectFunction: PodcastSpotify,
+    tags: ["International"],
+    accountKey: "spotify",
   },
 };

--- a/src/sync/podcast/spotify.ts
+++ b/src/sync/podcast/spotify.ts
@@ -1,0 +1,91 @@
+// Experimental publisher (待线上验证)
+import type { PodcastData, SyncData } from "~sync/common";
+
+export async function PodcastSpotify(data: SyncData) {
+  function waitForElement(selector: string, timeout = 15000): Promise<Element> {
+    return new Promise((resolve, reject) => {
+      const exist = document.querySelector(selector);
+      if (exist) {
+        resolve(exist);
+        return;
+      }
+
+      const observer = new MutationObserver(() => {
+        const found = document.querySelector(selector);
+        if (found) {
+          observer.disconnect();
+          resolve(found);
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+      setTimeout(() => {
+        observer.disconnect();
+        reject(new Error(`元素 "${selector}" 在 ${timeout}ms 内未出现`));
+      }, timeout);
+    });
+  }
+
+  function sleep(timeout: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, timeout));
+  }
+
+  try {
+    const { title, description, audio } = data.data as PodcastData;
+
+    await waitForElement("input#uploadAreaInput");
+    await sleep(1000);
+
+    console.debug("try upload file", audio);
+    const fileInput = document.querySelector("input#uploadAreaInput") as HTMLInputElement | null;
+    console.debug("fileInput -->", fileInput);
+    if (!fileInput) {
+      console.debug("未找到文件输入元素");
+      return;
+    }
+
+    const response = await fetch(audio.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const ext = audio.name.split(".").pop() || "mp3";
+    const uploadFile = new File([arrayBuffer], `${title}.${ext}`, { type: audio.type });
+    console.debug("uploadFile", uploadFile);
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(uploadFile);
+    fileInput.files = dataTransfer.files;
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+    console.debug("文件上传操作完成");
+
+    await waitForElement('input[name="title"]');
+    await sleep(2000);
+    const titleInput = document.querySelector('input[name="title"]') as HTMLInputElement | null;
+    console.debug("titleInput", titleInput);
+    if (titleInput) {
+      titleInput.value = title;
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+      titleInput.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    const editor = document.querySelector('div[contenteditable="true"]') as HTMLElement | null;
+    console.debug("qlEditor", editor);
+    if (!editor) {
+      console.debug("未找到编辑器元素");
+      return;
+    }
+
+    editor.focus();
+    await sleep(1000);
+    const pasteEvent = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: new DataTransfer(),
+    });
+    pasteEvent.clipboardData?.setData("text/plain", description || "");
+    editor.dispatchEvent(pasteEvent);
+    editor.dispatchEvent(new Event("input", { bubbles: true }));
+    editor.dispatchEvent(new Event("change", { bubbles: true }));
+  } catch (error) {
+    console.error("Spotify 播客上传失败:", error);
+  }
+}

--- a/src/sync/video/douyin.ts
+++ b/src/sync/video/douyin.ts
@@ -62,6 +62,30 @@ export async function VideoDouyin(data: SyncData) {
     console.log("视频上传事件已触发");
   }
 
+  // 按视频宽高比挑选封面(注入函数无法 import 共享工具,内联实现):横版优先横封面、竖版优先竖封面,回退 cover
+  async function pickCoverByAspect(
+    videoFile: FileData | undefined,
+    coverImg?: FileData,
+    horizontalCoverImg?: FileData,
+    verticalCoverImg?: FileData,
+  ): Promise<FileData | undefined> {
+    if (!horizontalCoverImg && !verticalCoverImg) return coverImg;
+    let isLandscape = false;
+    if (videoFile?.url) {
+      const dims = await new Promise<{ width: number; height: number } | null>((resolve) => {
+        const probe = document.createElement("video");
+        probe.preload = "metadata";
+        probe.onloadedmetadata = () => resolve({ width: probe.videoWidth, height: probe.videoHeight });
+        probe.onerror = () => resolve(null);
+        probe.src = videoFile.url;
+      });
+      if (dims) isLandscape = dims.width > dims.height;
+    }
+    return isLandscape
+      ? horizontalCoverImg || coverImg || verticalCoverImg
+      : verticalCoverImg || coverImg || horizontalCoverImg;
+  }
+
   async function uploadCover(cover: FileData): Promise<void> {
     console.log("尝试上传封面", cover);
     const coverUploadContainer = await waitForElement("div.content-upload-new");
@@ -111,7 +135,8 @@ export async function VideoDouyin(data: SyncData) {
   }
 
   try {
-    const { content, video, title, tags, cover, scheduledPublishTime } = data.data as VideoData;
+    const { content, video, title, tags, cover, horizontalCover, verticalCover, scheduledPublishTime } =
+      data.data as VideoData;
     // 处理视频上传
     if (video) {
       const response = await fetch(video.url);
@@ -170,10 +195,11 @@ export async function VideoDouyin(data: SyncData) {
       }
     }
 
-    // 处理封面上传
-    if (cover) {
+    // 处理封面上传:按视频宽高比挑选横/竖封面
+    const chosenCover = await pickCoverByAspect(video, cover, horizontalCover, verticalCover);
+    if (chosenCover) {
       await new Promise((resolve) => setTimeout(resolve, 2000));
-      await uploadCover(cover);
+      await uploadCover(chosenCover);
     }
 
     // 处理定时发布

--- a/src/sync/video/douyin.ts
+++ b/src/sync/video/douyin.ts
@@ -196,8 +196,10 @@ export async function VideoDouyin(data: SyncData) {
           console.log("定时发布时间已设置:", publishTimeInput.value);
         }
       }
+    }
+
+    if (data.isAutoPublish === true) {
       await new Promise((resolve) => setTimeout(resolve, 3000));
-      // 处理自动发布
       const buttons = document.querySelectorAll("button");
       const publishButton = Array.from(buttons).find((button) => button.textContent === "发布");
 

--- a/src/sync/video/iqiyi.ts
+++ b/src/sync/video/iqiyi.ts
@@ -23,6 +23,33 @@ export async function VideoIqiyi(data: SyncData) {
     });
   }
 
+  async function publishIfAutoEnabled(): Promise<void> {
+    if (data.isAutoPublish !== true) return;
+
+    // 轮询期间重新查询按钮，避免页面重渲染后持有失效节点；视频处理较慢，最多约 60s
+    const findPublishButton = () =>
+      Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("发布"));
+
+    let publishButton = findPublishButton();
+    for (let i = 0; i < 60; i++) {
+      publishButton = findPublishButton();
+      if (publishButton && publishButton.getAttribute("aria-disabled") !== "true") break;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (!publishButton) {
+      console.debug('未找到"发布"按钮');
+      return;
+    }
+    if (publishButton.getAttribute("aria-disabled") === "true") {
+      console.debug("发布按钮仍不可用，跳过自动发布");
+      return;
+    }
+
+    console.debug("sendButton clicked");
+    publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+  }
+
   try {
     const { title, content, video, tags, cover, description, original } = data.data as VideoData;
     if (!video) {
@@ -113,6 +140,8 @@ export async function VideoIqiyi(data: SyncData) {
         confirmBtn?.click();
       }
     }
+
+    await publishIfAutoEnabled();
   } catch (error) {
     console.error("爱奇艺视频发布失败:", error);
   }

--- a/src/sync/video/rednote.ts
+++ b/src/sync/video/rednote.ts
@@ -240,21 +240,26 @@ export async function VideoRednote(data: SyncData) {
   if (scheduledPublishTime) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     await setScheduledPublishTime(scheduledPublishTime);
-    // 处理发布按钮
-    const buttons = document.querySelectorAll("button");
-    const publishButton = Array.from(buttons).find((button) => button.textContent?.includes("发布"));
+  }
 
-    if (publishButton) {
-      // 等待按钮可用
-      while (publishButton.getAttribute("aria-disabled") === "true") {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
+  if (data.isAutoPublish === true) {
+    // 轮询期间重新查询按钮，避免页面重渲染后持有失效节点；视频处理较慢，最多约 60s
+    const findPublishButton = () =>
+      Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("发布"));
 
-      if (publishButton) {
-        publishButton.dispatchEvent(new Event("click", { bubbles: true }));
-        await new Promise((resolve) => setTimeout(resolve, 10000));
-        window.location.href = "https://creator.xiaohongshu.com/new/note-manager";
-      }
+    let publishButton = findPublishButton();
+    for (let i = 0; i < 60; i++) {
+      publishButton = findPublishButton();
+      if (publishButton && publishButton.getAttribute("aria-disabled") !== "true") break;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (publishButton && publishButton.getAttribute("aria-disabled") !== "true") {
+      publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+      window.location.href = "https://creator.xiaohongshu.com/new/note-manager";
+    } else {
+      console.debug("小红书：发布按钮仍不可用，跳过自动发布");
     }
   }
 }

--- a/src/sync/video/tencentvideo.ts
+++ b/src/sync/video/tencentvideo.ts
@@ -23,6 +23,33 @@ export async function VideoTencentVideo(data: SyncData) {
     });
   }
 
+  async function publishIfAutoEnabled(): Promise<void> {
+    if (data.isAutoPublish !== true) return;
+
+    // 轮询期间重新查询按钮，避免页面重渲染后持有失效节点；视频处理较慢，最多约 60s
+    const findPublishButton = () =>
+      Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("发布"));
+
+    let publishButton = findPublishButton();
+    for (let i = 0; i < 60; i++) {
+      publishButton = findPublishButton();
+      if (publishButton && publishButton.getAttribute("aria-disabled") !== "true") break;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (!publishButton) {
+      console.debug('未找到"发布"按钮');
+      return;
+    }
+    if (publishButton.getAttribute("aria-disabled") === "true") {
+      console.debug("发布按钮仍不可用，跳过自动发布");
+      return;
+    }
+
+    console.debug("sendButton clicked");
+    publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+  }
+
   try {
     const { title, content, video, cover, description } = data.data as VideoData;
     if (!video) {
@@ -82,6 +109,8 @@ export async function VideoTencentVideo(data: SyncData) {
         confirmBtn?.click();
       }
     }
+
+    await publishIfAutoEnabled();
   } catch (error) {
     console.error("腾讯视频发布失败:", error);
   }

--- a/src/sync/video/weixinchannel.ts
+++ b/src/sync/video/weixinchannel.ts
@@ -5,7 +5,7 @@
  * @date 2024-01-01
  */
 
-import type { SyncData, VideoData } from "../common";
+import type { FileData, SyncData, VideoData } from "../common";
 
 /**
  * 微信视频号视频发布处理函数
@@ -252,6 +252,30 @@ export async function VideoWeiXinChannel(data: SyncData) {
    * 上传视频封面
    * @param cover 封面图片信息
    */
+  // 按视频宽高比挑选封面(注入函数无法 import 共享工具,内联实现):横版优先横封面、竖版优先竖封面,回退 cover
+  async function pickCoverByAspect(
+    videoFile: FileData | undefined,
+    coverImg?: FileData,
+    horizontalCoverImg?: FileData,
+    verticalCoverImg?: FileData,
+  ): Promise<FileData | undefined> {
+    if (!horizontalCoverImg && !verticalCoverImg) return coverImg;
+    let isLandscape = false;
+    if (videoFile?.url) {
+      const dims = await new Promise<{ width: number; height: number } | null>((resolve) => {
+        const probe = document.createElement("video");
+        probe.preload = "metadata";
+        probe.onloadedmetadata = () => resolve({ width: probe.videoWidth, height: probe.videoHeight });
+        probe.onerror = () => resolve(null);
+        probe.src = videoFile.url;
+      });
+      if (dims) isLandscape = dims.width > dims.height;
+    }
+    return isLandscape
+      ? horizontalCoverImg || coverImg || verticalCoverImg
+      : verticalCoverImg || coverImg || horizontalCoverImg;
+  }
+
   async function uploadCover(cover: { url: string; name: string; type?: string }): Promise<void> {
     try {
       console.debug("tryCover", cover);
@@ -330,7 +354,16 @@ export async function VideoWeiXinChannel(data: SyncData) {
   }
 
   try {
-    const { content, video, title, tags = [], cover, scheduledPublishTime } = data.data as VideoData;
+    const {
+      content,
+      video,
+      title,
+      tags = [],
+      cover,
+      horizontalCover,
+      verticalCover,
+      scheduledPublishTime,
+    } = data.data as VideoData;
 
     // 处理视频上传
     if (video) {
@@ -398,8 +431,9 @@ export async function VideoWeiXinChannel(data: SyncData) {
       }
     }
 
-    if (cover) {
-      await uploadCover(cover);
+    const chosenCover = await pickCoverByAspect(video, cover, horizontalCover, verticalCover);
+    if (chosenCover) {
+      await uploadCover(chosenCover);
     }
 
     // 处理原创声明

--- a/src/sync/video/weixinchannel.ts
+++ b/src/sync/video/weixinchannel.ts
@@ -441,15 +441,16 @@ export async function VideoWeiXinChannel(data: SyncData) {
       }
     }
 
+    const wujieApp = document.querySelector("wujie-app");
+    const root = wujieApp?.shadowRoot || document;
+
     // 处理定时发布
     if (scheduledPublishTime) {
       await new Promise((resolve) => setTimeout(resolve, 2000));
-
-      const wujieApp = document.querySelector("wujie-app");
-      const root = wujieApp?.shadowRoot || document;
-
       await setScheduledPublishTime(scheduledPublishTime, root);
-      // 等待内容填写完成
+    }
+
+    if (data.isAutoPublish === true) {
       await new Promise((resolve) => setTimeout(resolve, 5000));
 
       // 处理发布按钮 - 支持shadow DOM查询

--- a/src/sync/video/youku.ts
+++ b/src/sync/video/youku.ts
@@ -23,6 +23,33 @@ export async function VideoYouku(data: SyncData) {
     });
   }
 
+  async function publishIfAutoEnabled(): Promise<void> {
+    if (data.isAutoPublish !== true) return;
+
+    // 轮询期间重新查询按钮，避免页面重渲染后持有失效节点；视频处理较慢，最多约 60s
+    const findPublishButton = () =>
+      Array.from(document.querySelectorAll("button")).find((button) => button.textContent?.includes("发布"));
+
+    let publishButton = findPublishButton();
+    for (let i = 0; i < 60; i++) {
+      publishButton = findPublishButton();
+      if (publishButton && publishButton.getAttribute("aria-disabled") !== "true") break;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    if (!publishButton) {
+      console.debug('未找到"发布"按钮');
+      return;
+    }
+    if (publishButton.getAttribute("aria-disabled") === "true") {
+      console.debug("发布按钮仍不可用，跳过自动发布");
+      return;
+    }
+
+    console.debug("sendButton clicked");
+    publishButton.dispatchEvent(new Event("click", { bubbles: true }));
+  }
+
   try {
     const { title, content, video, tags, cover, description } = data.data as VideoData;
     if (!video) {
@@ -95,6 +122,8 @@ export async function VideoYouku(data: SyncData) {
         cropBtn?.click();
       }
     }
+
+    await publishIfAutoEnabled();
   } catch (error) {
     console.error("优酷视频发布失败:", error);
   }

--- a/src/sync/video/zhihu.ts
+++ b/src/sync/video/zhihu.ts
@@ -44,8 +44,103 @@ export async function VideoZhihu(data: SyncData) {
     console.log("视频上传事件已触发");
   }
 
+  async function uploadCover(cover: NonNullable<VideoData["cover"]>): Promise<void> {
+    console.debug("tryCover", cover);
+    const coverButton = (await waitForElement("div.VideoUploadForm-imageEditButton")) as HTMLElement;
+    console.debug("coverButton -->", coverButton);
+    if (!coverButton) return;
+
+    coverButton.click();
+    await waitForElement("h3.Modal-title");
+
+    const uploadTabs = document.querySelectorAll("h3.Modal-title div");
+    const localUploadTab = Array.from(uploadTabs).find((tab) => tab.textContent?.trim() === "本地上传") as
+      | HTMLElement
+      | undefined;
+    console.debug("localUploadDiv -->", localUploadTab);
+    if (!localUploadTab) return;
+
+    localUploadTab.click();
+    const fileInput = (await waitForElement(
+      "input[type='file'][accept='image/png,image/jpeg,image/jpg']",
+    )) as HTMLInputElement;
+    console.debug("fileInput -->", fileInput);
+    if (!fileInput || !cover.type?.includes("image/")) return;
+
+    const response = await fetch(cover.url);
+    const arrayBuffer = await response.arrayBuffer();
+    const coverFile = new File([arrayBuffer], cover.name, { type: cover.type });
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(coverFile);
+    fileInput.files = dataTransfer.files;
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+    fileInput.dispatchEvent(new Event("input", { bubbles: true }));
+    console.debug("封面上传操作已触发");
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const buttons = document.querySelectorAll("button");
+    const confirmButton = Array.from(buttons).find((button) => button.textContent?.trim() === "确认选择") as
+      | HTMLElement
+      | undefined;
+    console.debug("doneButton -->", confirmButton);
+    confirmButton?.click();
+  }
+
+  async function addTags(tags: string[]): Promise<void> {
+    if (tags.length === 0) return;
+
+    let contentEditor: HTMLElement | null = null;
+    try {
+      contentEditor = (await waitForElement('div[contenteditable="true"]', 5000)) as HTMLElement;
+    } catch (error) {
+      console.debug("未找到话题编辑器", error);
+      return;
+    }
+
+    for (const tag of tags.slice(0, 5)) {
+      console.debug("添加标签", tag);
+      contentEditor.focus();
+      const pasteEvent = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: new DataTransfer(),
+      });
+      pasteEvent.clipboardData.setData("text/plain", `#${tag}`);
+      contentEditor.dispatchEvent(pasteEvent);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const activeSuggestion = document.querySelector("div.Menu-item.is-active") as HTMLElement | null;
+      if (activeSuggestion) {
+        const newTopic = activeSuggestion.querySelector("span.new-topic") as HTMLElement | null;
+        if (newTopic?.textContent?.trim() === "创建新话题") {
+          console.debug("创建新话题", tag);
+          newTopic.click();
+        } else {
+          activeSuggestion.click();
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    contentEditor.blur();
+  }
+
+  async function publishIfAutoEnabled(): Promise<void> {
+    if (data.isAutoPublish !== true) return;
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    const divs = document.querySelectorAll("div");
+    const publishButton = Array.from(divs).find((div) => div.textContent?.trim() === "发布") as HTMLElement | undefined;
+    if (publishButton) {
+      console.debug("sendButton clicked");
+      publishButton.click();
+    } else {
+      console.debug('未找到"发布"按钮');
+    }
+  }
+
   try {
-    const { content, video, title, description } = data.data as VideoData;
+    const { content, video, title, description, tags = [], cover } = data.data as VideoData;
     // 处理视频上传
     if (video) {
       const response = await fetch(video.url);
@@ -83,14 +178,19 @@ export async function VideoZhihu(data: SyncData) {
       contentEditor.blur();
     }
 
-    // 如果需要保留换行符，可以使用 innerHTML
-    // editor.innerHTML = contentToInsert.replace(/\n/g, '<br>');
+    await addTags(tags);
 
-    // 如果需要自动发布，可以添加类似的逻辑
-    // if (data.isAutoPublish) {
-    //   // 自动发布逻辑
-    // }
+    if (cover) {
+      // 封面为尽力而为：上传失败(如封面 UI 变更/超时)不应阻断后续发布
+      try {
+        await uploadCover(cover);
+      } catch (coverError) {
+        console.warn("知乎封面上传失败，跳过封面继续发布:", coverError);
+      }
+    }
+
+    await publishIfAutoEnabled();
   } catch (error) {
-    console.error("DouyinVideo 发布过程中出错:", error);
+    console.error("知乎视频发布过程中出错:", error);
   }
 }

--- a/src/tabs/publish.tsx
+++ b/src/tabs/publish.tsx
@@ -224,7 +224,7 @@ export default function Publish() {
 
   const processVideo = async (data: SyncData) => {
     setNotice(chrome.i18n.getMessage("processingContent"));
-    const { video, cover, verticalCover, scheduledPublishTime } = data.data as VideoData;
+    const { video, cover, verticalCover, horizontalCover, scheduledPublishTime } = data.data as VideoData;
 
     if (!video) {
       console.warn("视频数据不存在");
@@ -240,6 +240,11 @@ export default function Publish() {
     if (verticalCover) {
       processedVerticalCover = await processFile(verticalCover);
     }
+    // 此前漏处理 horizontalCover,导致横版封面以裸 URL 传入注入脚本无法使用
+    let processedHorizontalCover: FileData | null = null;
+    if (horizontalCover) {
+      processedHorizontalCover = await processFile(horizontalCover);
+    }
 
     return {
       ...data,
@@ -248,6 +253,7 @@ export default function Publish() {
         video: processedVideo,
         cover: processedCover || cover,
         verticalCover: processedVerticalCover || verticalCover,
+        horizontalCover: processedHorizontalCover || horizontalCover,
         scheduledPublishTime: scheduledPublishTime || 0,
       },
     };


### PR DESCRIPTION
## Summary

Ports fixes and missing platforms from the **aibeike 内容同步助手 1.6.5** reference, bringing publish-script coverage roughly to parity (article 23 → 36, +Pinterest dynamic, +Spotify podcast).

### Bug / quality fixes (existing platforms)
- **fix(video):** gate every final auto-publish click on `isAutoPublish` — douyin / rednote / weixinchannel previously fired publish from the *scheduled-only* branch **without** the gate, so a schedule-only post (isAutoPublish=false) could be auto-published. Wired gated terminal publish for iqiyi / youku / tencentvideo (bounded, re-querying `aria-disabled` wait); completed zhihu video (topic tags, best-effort cover, gated publish).
- **fix(article):** weibo article never published when there was no cover (publish was nested inside `if (cover)`); also wrap uploaded body images as weibo `figure`+`srcset`.
- **feat(video):** process `horizontalCover` in `processVideo` (was dropped); douyin / weixinchannel pick horizontal vs vertical cover by the video's aspect ratio.

### New platforms (15, all experimental)
- **Article (13):** Netease(163), QQ/企鹅号, Dingduanhao, Kuaichuanhao, Yidianzixun, Jianpian, Tonghuashun, Dongchedi, Zsxq, Sohu, Aliyun, TencentYun, X long-form.
- **Dynamic (1):** Pinterest. **Podcast (1):** Spotify.

## ⚠️ Experimental — needs live verification
All 15 new platforms are **untested** — built from the aibeike reference and could not be verified against live, logged-in pages. Selectors / flows must be regression-tested live before relying on them. Every final publish click is gated on `isAutoPublish`.

The 4 API-heavy article platforms (Sohu / Aliyun / TencentYun / X long-form) ship **DOM-only** — cloud-storage STS signing and the X GraphQL draft API were intentionally **not** ported (left as `TODO`), since they need a logged-in session + signed-request samples to implement correctly. Body-image CDN re-upload is likewise deferred.

## Notes
- Self-contained injection preserved (helpers inlined per the `executeScript({func})` serialization constraint).
- `biome` lint + `tsc --noEmit` pass; no `pnpm-lock.yaml` changes.

## Still uncovered (optional)
X video (video coverage already leads aibeike); aibeike's routing-only extras (格隆汇 / 健康界 / 凯迪网); 飞书 group (approximated by the generic Webhook platform).
